### PR TITLE
Fix role casing and drawer menu

### DIFF
--- a/app/src/main/java/com/example/quiz1/activity/LoginActivity.kt
+++ b/app/src/main/java/com/example/quiz1/activity/LoginActivity.kt
@@ -38,9 +38,12 @@ class LoginActivity : AppCompatActivity() {
                     override fun onResponse(call: Call<Usuario>, response: Response<Usuario>) {
                         if (response.isSuccessful) {
                             val user = response.body() ?: return
+                            // Guardamos el rol en mayúsculas para que el menú
+                            // pueda evaluarlo sin depender del formato que
+                            // envíe el API.
                             prefs.edit()
                                 .putString("cedula", user.cedula)
-                                .putString("rol", user.rol)
+                                .putString("rol", user.rol.uppercase())
                                 .apply()
                             startActivity(Intent(this@LoginActivity, MenuActivity::class.java))
                             finish()

--- a/app/src/main/java/com/example/quiz1/activity/MenuActivity.kt
+++ b/app/src/main/java/com/example/quiz1/activity/MenuActivity.kt
@@ -40,6 +40,10 @@ class MenuActivity : AppCompatActivity() {
         val rol = prefs.getString("rol", "")
         findViewById<TextView>(R.id.tvBienvenida).text = "Bienvenido, $cedula"
 
+        // Obtiene los items del menú según el rol almacenado en preferencias.
+        // El API entrega los roles en mayúsculas (ADMINISTRADOR, PROFESOR,
+        // ALUMNO, MATRICULADOR), por lo que se normaliza a mayúsculas antes de
+        // comparar.
         items.addAll(obtenerItemsPorRol(rol))
 
         val recyclerView = findViewById<RecyclerView>(R.id.menuRecyclerView)
@@ -61,8 +65,8 @@ class MenuActivity : AppCompatActivity() {
     }
 
     private fun obtenerItemsPorRol(rol: String?): List<Pair<String, androidx.fragment.app.Fragment>> {
-        return when (rol) {
-            "Administrador" -> listOf(
+        return when (rol?.uppercase()) {
+            "ADMINISTRADOR" -> listOf(
                 "Alumnos" to AlumnosFragment(),
                 "Profesores" to ProfesoresFragment(),
                 "Usuarios" to UsuariosFragment(),
@@ -73,9 +77,9 @@ class MenuActivity : AppCompatActivity() {
                 "Matrículas" to MatriculaFragment(),
                 "Plan de Estudio" to PlanEstudioFragment()
             )
-            "Matriculador" -> listOf("Matrículas" to MatriculaFragment())
-            "Profesor" -> emptyList()
-            "Alumno" -> emptyList()
+            "MATRICULADOR" -> listOf("Matrículas" to MatriculaFragment())
+            "PROFESOR" -> emptyList()
+            "ALUMNO" -> emptyList()
             else -> emptyList()
         }
     }


### PR DESCRIPTION
## Summary
- ensure `LoginActivity` stores user roles in uppercase so menu logic matches
- allow `MenuActivity` to handle roles in uppercase and add clarifying comments

## Testing
- `./gradlew assembleDebug --offline` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683f55b45950832f9f42a9152086af1b